### PR TITLE
allow XHTML inside wadl:doc

### DIFF
--- a/wadl.xsl
+++ b/wadl.xsl
@@ -383,11 +383,8 @@
                 </xsl:variable>
                 <a href="{$url}"><xsl:value-of select="$url"/></a>
             </xsl:when>
-            <xsl:when test="contains($content, 'Example')">
-               	<div style="white-space:pre-wrap"><pre><xsl:value-of select="."/></pre></div>
-            </xsl:when>
             <xsl:otherwise>
-               	<xsl:value-of select="$content"/>
+               	<xsl:copy-of select="."/>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:for-each>
@@ -444,7 +441,7 @@
                 </xsl:if>
             </td>
         <xsl:if test="wadl:doc">
-            <td><xsl:value-of select="wadl:doc"/></td>
+            <td><xsl:copy-of select="wadl:doc"/></td>
         </xsl:if>
     </tr>
 </xsl:template>

--- a/wadl.xsl
+++ b/wadl.xsl
@@ -380,7 +380,7 @@
                         <xsl:otherwise><xsl:value-of select="text()"/></xsl:otherwise>
                     </xsl:choose>
                 </xsl:variable>
-                <a href="{$url}"><xsl:value-of select="$url"/></a>
+                <a href="{$url}" rel="nofollow"><xsl:value-of select="$url"/></a>
             </xsl:when>
             <xsl:otherwise>
                	<xsl:copy-of select="."/>

--- a/wadl.xsl
+++ b/wadl.xsl
@@ -10,7 +10,6 @@
     and the README.txt for other usage information.
     Note that the contents of a doc element is rendered as a:
         * hyperlink if the title attribute contains is equal to 'Example'
-        * mono-spaced font ('pre' tag) if content contains the text 'Example'
 			
     Limitations:
         * Ignores globally defined methods, referred to from a resource using a method reference element.


### PR DESCRIPTION
Hi,

with the current version of your wadl.xsl any tag inside a wadl:doc-tag is discarded upon displaying.
To me a nice documentation should contain e.g. new-lines to be easy to read. To achieve this XHTML-tags like <p/> or <br/> are required.

I modified the wadl.xsl to copy tags contained in wadl:doc-tags for wadl:application and presumably most other wadl:doc-tags.

Please have a look into this pull-request.

Regards

Matthias
