### PR TITLE
allow HTML content

### DIFF
--- a/wadl.xsl
+++ b/wadl.xsl
@@ -387,7 +387,7 @@
                	<div style="white-space:pre-wrap"><pre><xsl:value-of select="."/></pre></div>
             </xsl:when>
             <xsl:otherwise>
-               	<xsl:value-of select="$content"/>
+               	<xsl:value-of select="$content" disable-output-escaping="yes"/>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:for-each>


### PR DESCRIPTION
Maybe there is a better way but I found that by disabling output escaping on the description/documentation content that I am able to write HTML content and have it rendered correctly using your stylesheet.
